### PR TITLE
Timeout for http.Client and bug fix

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/net/html"
 
@@ -261,6 +262,11 @@ func (c *Collector) WithTransport(transport *http.Transport) {
 // DisableCookies turns off cookie handling for this collector
 func (c *Collector) DisableCookies() {
 	c.backend.Client.Jar = nil
+}
+
+// SetClientTimeout overrides the default timeout for this collector
+func (c *Collector) SetClientTimeout(timeout time.Duration) {
+	c.backend.Client.Timeout = timeout
 }
 
 func (c *Collector) handleOnRequest(r *Request) {

--- a/colly.go
+++ b/colly.go
@@ -268,8 +268,8 @@ func (c *Collector) DisableCookies() {
 	c.backend.Client.Jar = nil
 }
 
-// SetClientTimeout overrides the default timeout for this collector
-func (c *Collector) SetClientTimeout(timeout time.Duration) {
+// SetRequestTimeout overrides the default timeout (10 seconds) for this collector
+func (c *Collector) SetRequestTimeout(timeout time.Duration) {
 	c.backend.Client.Timeout = timeout
 }
 

--- a/http_backend.go
+++ b/http_backend.go
@@ -70,7 +70,8 @@ func (h *httpBackend) Init() {
 	h.LimitRules = make([]*LimitRule, 0, 8)
 	jar, _ := cookiejar.New(nil)
 	h.Client = &http.Client{
-		Jar: jar,
+		Jar:     jar,
+		Timeout: 10 * time.Second,
 	}
 	h.lock = &sync.Mutex{}
 }

--- a/http_backend.go
+++ b/http_backend.go
@@ -105,7 +105,12 @@ func (h *httpBackend) Do(request *http.Request) (*Response, error) {
 			<-r.waitChan
 		}(r)
 	}
+
 	res, err := h.Client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hello!

This PR adds a default timeout to the http.Client (since a timeout of 0 is == no timeout in go) and adds collector.SetClientTimeout() to override it[1]. Also added a check on err after client.Do since it can cause a panic later on if the request fails.

[1]:
example: `c.SetClientTimeout(5 * time.Second)`
