### PR TITLE
Caching when CacheDir is defined

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -87,7 +87,7 @@ type HTMLElement struct {
 
 // Context provides a tiny layer for passing data between callbacks
 type Context struct {
-	ContextMap map[string]string
+	contextMap map[string]string
 	lock       *sync.Mutex
 }
 
@@ -110,7 +110,7 @@ func NewCollector() *Collector {
 // NewContext initializes a new Context instance
 func NewContext() *Context {
 	return &Context{
-		ContextMap: make(map[string]string),
+		contextMap: make(map[string]string),
 		lock:       &sync.Mutex{},
 	}
 }
@@ -364,17 +364,25 @@ func (r *Request) Post(URL string, requestData map[string]string) error {
 	return r.collector.scrape(r.AbsoluteURL(URL), "POST", r.Depth+1, requestData)
 }
 
+func (c *Context) UnmarshalBinary(data []byte) error {
+	return nil
+}
+
+func (c *Context) MarshalBinary() (data []byte, err error) {
+	return nil, nil
+}
+
 // Put stores a value in Context
 func (c *Context) Put(key, value string) {
 	c.lock.Lock()
-	c.ContextMap[key] = value
+	c.contextMap[key] = value
 	c.lock.Unlock()
 }
 
 // Get retrieves a value from Context. If no value found for `k`
 // Get returns an empty string if key not found
 func (c *Context) Get(key string) string {
-	if v, ok := c.ContextMap[key]; ok {
+	if v, ok := c.contextMap[key]; ok {
 		return v
 	}
 	return ""

--- a/colly.go
+++ b/colly.go
@@ -30,7 +30,9 @@ type Collector struct {
 	// MaxBodySize is the limit of the retrieved response body in bytes.
 	// `0` means unlimited.
 	// The default value for MaxBodySize is 10MB (10 * 1024 * 1024 bytes).
-	MaxBodySize       int
+	MaxBodySize int
+	// CacheDir specifies a location where GET requests are cached as files.
+	// When it's not defined, caching is disabled.
 	CacheDir          string
 	visitedURLs       []string
 	htmlCallbacks     map[string]HTMLCallback

--- a/http_backend.go
+++ b/http_backend.go
@@ -123,15 +123,18 @@ func (h *httpBackend) Cache(request *http.Request, bodySize int, cacheDir string
 	}
 	if _, err := os.Stat(dir); err != nil {
 		if err := os.MkdirAll(dir, 0750); err != nil {
-			return nil, err
+			return resp, err
 		}
 	}
-	file, err := os.Create(filename)
+	file, err := os.Create(filename + "~")
 	defer file.Close()
 	if err != nil {
-		return nil, err
+		return resp, err
 	}
-	return resp, gob.NewEncoder(file).Encode(resp)
+	if err := gob.NewEncoder(file).Encode(resp); err != nil {
+		return resp, err
+	}
+	return resp, os.Rename(filename+"~", filename)
 }
 
 func (h *httpBackend) Do(request *http.Request, bodySize int) (*Response, error) {


### PR DESCRIPTION
I added some basic caching support. Changes should be backward compatible and enable cache only when `CacheDir` is defined. I needed to make `ContextMap` public to make request object serializable with gob.