### PR TITLE
Copy the headers from the last request on redirect

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -178,7 +178,6 @@ func (c *Collector) scrape(u, method string, depth int, requestData io.Reader, c
 		return err
 	}
 	req.Header.Set("User-Agent", c.UserAgent)
-
 	if ctx == nil {
 		ctx = NewContext()
 	}

--- a/colly.go
+++ b/colly.go
@@ -178,6 +178,7 @@ func (c *Collector) scrape(u, method string, depth int, requestData io.Reader, c
 		return err
 	}
 	req.Header.Set("User-Agent", c.UserAgent)
+
 	if ctx == nil {
 		ctx = NewContext()
 	}
@@ -369,8 +370,16 @@ func (c *Collector) checkRedirectFunc() func(req *http.Request, via []*http.Requ
 			return http.ErrUseLastResponse
 		}
 
+		lastRequest := via[len(via)-1]
+
 		// Copy the headers from last request
-		req.Header = via[len(via)-1].Header
+		req.Header = lastRequest.Header
+
+		// If domain has changed, remove the Authorization-header if it exists
+		if req.URL.Host != lastRequest.URL.Host {
+			req.Header.Del("Authorization")
+		}
+
 		return nil
 	}
 }

--- a/colly.go
+++ b/colly.go
@@ -4,6 +4,7 @@ package colly
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -130,6 +131,7 @@ func (c *Collector) Init() {
 	c.MaxBodySize = 10 * 1024 * 1024
 	c.backend = &httpBackend{}
 	c.backend.Init()
+	c.backend.Client.CheckRedirect = c.checkRedirectFunc()
 	c.wg = &sync.WaitGroup{}
 	c.lock = &sync.Mutex{}
 }
@@ -354,6 +356,23 @@ func (c *Collector) Cookies(URL string) []*http.Cookie {
 		return nil
 	}
 	return c.backend.Client.Jar.Cookies(u)
+}
+
+func (c *Collector) checkRedirectFunc() func(req *http.Request, via []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if !c.isDomainAllowed(req.URL.Host) {
+			return fmt.Errorf("Not following redirect to %s because its not in AllowedDomains", req.URL.Host)
+		}
+
+		// Honor golangs default of maximum of 10 redirects
+		if len(via) >= 10 {
+			return http.ErrUseLastResponse
+		}
+
+		// Copy the headers from last request
+		req.Header = via[len(via)-1].Header
+		return nil
+	}
 }
 
 // Attr returns the selected attribute of a HTMLElement or empty string

--- a/http_backend.go
+++ b/http_backend.go
@@ -78,6 +78,16 @@ func (h *httpBackend) Init() {
 	h.Client = &http.Client{
 		Jar:     jar,
 		Timeout: 10 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Honor golangs default of maximum of 10 redirects
+			if len(via) >= 10 {
+				return http.ErrUseLastResponse
+			}
+
+			// Copy the headers from last request
+			req.Header = via[len(via)-1].Header
+			return nil
+		},
 	}
 	h.lock = &sync.RWMutex{}
 }

--- a/http_backend.go
+++ b/http_backend.go
@@ -78,16 +78,6 @@ func (h *httpBackend) Init() {
 	h.Client = &http.Client{
 		Jar:     jar,
 		Timeout: 10 * time.Second,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			// Honor golangs default of maximum of 10 redirects
-			if len(via) >= 10 {
-				return http.ErrUseLastResponse
-			}
-
-			// Copy the headers from last request
-			req.Header = via[len(via)-1].Header
-			return nil
-		},
 	}
 	h.lock = &sync.RWMutex{}
 }


### PR DESCRIPTION
Apparently headers does not survive a redirect in net/http (https://github.com/golang/go/issues/4800) so here's a fix for that. Probably not the most elegant way of doing it though